### PR TITLE
Get VPN IP from tun0 interface and update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 python-dotenv
+netifaces


### PR DESCRIPTION
- Added logic to fetch VPN IP automatically from tun0 or tun1 interfaces.
- Updated requirements.txt to include the necessary module.